### PR TITLE
fix(testing): Make GenericServiceEventHandling test deterministic

### DIFF
--- a/simulation-engine/pkg/components/components_test.go
+++ b/simulation-engine/pkg/components/components_test.go
@@ -192,6 +192,7 @@ func TestComponentFactory(t *testing.T) {
 
 func TestGenericServiceEventHandling(t *testing.T) {
 	service := NewGenericService("test-service")
+	service.FailureRate = 0.0 // Ensure deterministic behavior for this test
 	ctx := context.Background()
 	
 	// Start the service


### PR DESCRIPTION
The 'TestGenericServiceEventHandling' test was failing intermittently due to a non-deterministic failure simulation in the 'GenericService'. I've modified the test to set the 'FailureRate' to 0.0, ensuring that the test is deterministic and no longer subject to random failures.