### PR TITLE
Fix: Move frontend CI workflow to correct directory

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -5,24 +5,24 @@ on:
   push:
     branches: [ main, fix/ci-test-script ]
     paths:
-      - 'src/**'
-      - 'public/**'
-      - 'package*.json'
-      - 'vite.config.ts'
-      - 'tsconfig*.json'
-      - 'tailwind.config.ts'
-      - 'Dockerfile'
-      - '.github/workflows/new-frontend-ci.yml'
+      - 'frontend/src/**'
+      - 'frontend/public/**'
+      - 'frontend/package*.json'
+      - 'frontend/vite.config.ts'
+      - 'frontend/tsconfig*.json'
+      - 'frontend/tailwind.config.ts'
+      - 'frontend/Dockerfile'
+      - '.github/workflows/frontend-ci.yml'
   pull_request:
     branches: [ main ]
     paths:
-      - 'src/**'
-      - 'public/**'
-      - 'package*.json'
-      - 'vite.config.ts'
-      - 'tsconfig*.json'
-      - 'tailwind.config.ts'
-      - 'Dockerfile'
+      - 'frontend/src/**'
+      - 'frontend/public/**'
+      - 'frontend/package*.json'
+      - 'frontend/vite.config.ts'
+      - 'frontend/tsconfig*.json'
+      - 'frontend/tailwind.config.ts'
+      - 'frontend/Dockerfile'
 
 env:
   NODE_VERSION: '18'
@@ -33,6 +33,9 @@ jobs:
   test:
     name: Test Frontend
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
     
     steps:
     - name: Checkout code
@@ -43,6 +46,7 @@ jobs:
       with:
         node-version: ${{ env.NODE_VERSION }}
         cache: 'npm'
+        cache-dependency-path: frontend/package-lock.json
 
     - name: Install dependencies
       run: npm install
@@ -67,7 +71,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: build-files
-        path: dist/
+        path: frontend/dist/
         retention-days: 7
 
   docker-build:
@@ -113,8 +117,8 @@ jobs:
     - name: Build and push Docker image
       uses: docker/build-push-action@v5
       with:
-        context: .
-        file: ./Dockerfile
+        context: ./frontend
+        file: ./frontend/Dockerfile
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
@@ -127,6 +131,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
+    defaults:
+      run:
+        working-directory: frontend
     
     steps:
     - name: Checkout code
@@ -137,6 +144,7 @@ jobs:
       with:
         node-version: ${{ env.NODE_VERSION }}
         cache: 'npm'
+        cache-dependency-path: frontend/package-lock.json
 
     - name: Install dependencies
       run: npm install
@@ -155,7 +163,7 @@ jobs:
       if: always()
       with:
         name: playwright-report
-        path: playwright-report/
+        path: frontend/playwright-report/
         retention-days: 7
 
   deploy-staging:
@@ -197,7 +205,7 @@ jobs:
       uses: aquasecurity/trivy-action@master
       with:
         scan-type: 'fs'
-        scan-ref: '.'
+        scan-ref: './frontend'
         format: 'sarif'
         output: 'trivy-results.sarif'
 


### PR DESCRIPTION
The frontend GitHub Actions workflow was located in `frontend/.github/workflows`, which is not a location that GitHub Actions scans for workflows. This resulted in the frontend CI/CD pipeline not being triggered.

This change moves the frontend workflow file to the root `.github/workflows` directory, allowing it to be discovered and executed by GitHub Actions.

The workflow file has been updated to reflect the new location:
- Paths in the `on` trigger have been prefixed with `frontend/`.
- A `working-directory: frontend` has been added to jobs to ensure commands run in the correct context.
- The Docker build context and file paths have been updated.
- The old `frontend/.github` directory has been removed.